### PR TITLE
Change ResponseBody getANode logic

### DIFF
--- a/ql/src/semmle/go/Concepts.qll
+++ b/ql/src/semmle/go/Concepts.qll
@@ -366,7 +366,12 @@ module HTTP {
      * extend `HTTP::ResponseWriter` instead.
      */
     abstract class Range extends Variable {
-      /** Gets a data-flow node that is a use of this response writer. */
+      /**
+       * Gets a data-flow node that is a use of this response writer.
+       *
+       * Note that `PostUpdateNode`s for nodes that this predicate gets do not need to be
+       * included, as they are handled by the concrete `ResponseWriter`'s `getANode`.
+       */
       abstract DataFlow::Node getANode();
     }
   }
@@ -392,7 +397,10 @@ module HTTP {
     Redirect getARedirect() { result.getResponseWriter() = this }
 
     /** Gets a data-flow node that is a use of this response writer. */
-    DataFlow::Node getANode() { result = self.getANode() }
+    DataFlow::Node getANode() {
+      result = self.getANode() or
+      result.(PostUpdateNode).getPreUpdateNode() = self.getANode()
+    }
   }
 
   /** Provides a class for modeling new HTTP header-write APIs. */

--- a/ql/src/semmle/go/frameworks/stdlib/NetHttp.qll
+++ b/ql/src/semmle/go/frameworks/stdlib/NetHttp.qll
@@ -146,15 +146,11 @@ module NetHttp {
       )
       or
       exists(
-        TaintTracking::FunctionModel model, FunctionOutput modelOutput, FunctionInput modelInput,
-        DataFlow::CallNode call
+        TaintTracking::FunctionModel model
       |
         // A modelled function conveying taint from some input to the response writer,
         // e.g. `io.Copy(responseWriter, someTaintedReader)`
-        call = model.getACall() and
-        model.hasTaintFlow(modelInput, modelOutput) and
-        this = modelInput.getNode(call) and
-        responseWriter = modelOutput.getNode(call).(DataFlow::PostUpdateNode).getPreUpdateNode() and
+        model.flowStep(this, responseWriter) and
         responseWriter.getType().implements("net/http", "ResponseWriter")
       )
     }


### PR DESCRIPTION
I think this is slightly cleaner, as I'd expect `ResponseWriter.getANode` to get any node that refers to the `ResponseWriter`.

I'm not sure how much `getANode` should delegate to implementations here. It's possible that it shouldn't actually be abstract so that its implementation is conistent and all the user has to do is say which variables are `ResponseWriter`s.